### PR TITLE
おとあそびとおえかきの動作改善

### DIFF
--- a/components/features/sound-play/SoundBoard.tsx
+++ b/components/features/sound-play/SoundBoard.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { SoundButton } from './SoundButton';
-import { getSoundsByCategory, type SoundCategory } from '@/lib/constants/sounds';
+import {
+  getSoundsByCategory,
+  type SoundCategory,
+} from '@/lib/constants/sounds';
 import { GridLayout } from '@/components/layouts/GridLayout';
-import { cn } from '@/utils/cn';
+import { cn } from '@/lib/utils/cn';
 
 interface SoundBoardProps {
   category: SoundCategory;
@@ -15,16 +18,19 @@ export function SoundBoard({ category, className }: SoundBoardProps) {
 
   if (sounds.length === 0) {
     return (
-      <div className={cn(
-        "flex items-center justify-center p-8",
-        "bg-white/30 backdrop-blur-sm rounded-kotochan",
-        "border border-white/20",
-        className
-      )}>
+      <div
+        className={cn(
+          'flex items-center justify-center p-8',
+          'bg-white/30 backdrop-blur-sm rounded-kotochan',
+          'border border-white/20',
+          className
+        )}
+      >
         <div className="text-center">
           <span className="text-4xl mb-4 block">🎵</span>
           <p className="text-child-base text-gray-600">
-            この カテゴリには<br />
+            この カテゴリには
+            <br />
             まだ 音が ありません
           </p>
         </div>
@@ -33,12 +39,14 @@ export function SoundBoard({ category, className }: SoundBoardProps) {
   }
 
   return (
-    <div className={cn(
-      "bg-white/30 backdrop-blur-sm rounded-kotochan",
-      "border border-white/20 shadow-sm",
-      "p-4 sm:p-6",
-      className
-    )}>
+    <div
+      className={cn(
+        'bg-white/30 backdrop-blur-sm rounded-kotochan',
+        'border border-white/20 shadow-sm',
+        'p-4 sm:p-6',
+        className
+      )}
+    >
       <GridLayout
         columns={2}
         gap="medium"

--- a/components/features/sound-play/SoundButton.tsx
+++ b/components/features/sound-play/SoundButton.tsx
@@ -5,7 +5,7 @@ import { CircleButton } from '@/components/ui/CircleButton';
 import { Sparkles } from '@/components/ui/Sparkles';
 import { useSound } from '@/lib/hooks/useSound';
 import { type SoundItem } from '@/lib/constants/sounds';
-import { cn } from '@/utils/cn';
+import { cn } from '@/lib/utils/cn';
 
 interface SoundButtonProps {
   sound: SoundItem;
@@ -13,14 +13,21 @@ interface SoundButtonProps {
   className?: string;
 }
 
-const COLOR_MAP: Record<string, 'pink' | 'yellow' | 'mint' | 'blue' | 'orange' | 'purple' | 'brown'> = {
+const COLOR_MAP: Record<
+  string,
+  'pink' | 'yellow' | 'mint' | 'blue' | 'orange' | 'purple' | 'brown'
+> = {
   animals: 'pink',
   instruments: 'mint',
   effects: 'yellow',
-  background: 'blue'
+  background: 'blue',
 };
 
-export function SoundButton({ sound, size = 'large', className }: SoundButtonProps) {
+export function SoundButton({
+  sound,
+  size = 'large',
+  className,
+}: SoundButtonProps) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [showSparkles, setShowSparkles] = useState(false);
   const { play, isLoading } = useSound(sound.file);
@@ -38,7 +45,7 @@ export function SoundButton({ sound, size = 'large', className }: SoundButtonPro
     } finally {
       // 音声の長さまたは最小表示時間の長い方だけボタンを押下状態にする
       const displayDuration = Math.max(sound.duration * 1000, 800);
-      
+
       setTimeout(() => {
         setIsPlaying(false);
       }, displayDuration);
@@ -52,29 +59,26 @@ export function SoundButton({ sound, size = 'large', className }: SoundButtonPro
   const buttonColor = COLOR_MAP[sound.category] || 'pink';
 
   return (
-    <div className={cn("relative", className)}>
+    <div className={cn('relative', className)}>
       {showSparkles && (
-        <Sparkles
-          count={8}
-          className="absolute inset-0 pointer-events-none"
-        />
+        <Sparkles count={8} className="absolute inset-0 pointer-events-none" />
       )}
-      
+
       <CircleButton
         onClick={handlePlay}
         disabled={isPlaying || isLoading}
         color={buttonColor}
         size={size}
         className={cn(
-          "transition-all duration-200",
-          isPlaying && "scale-110 shadow-lg",
-          isLoading && "opacity-50 cursor-not-allowed"
+          'transition-all duration-200',
+          isPlaying && 'scale-110 shadow-lg',
+          isLoading && 'opacity-50 cursor-not-allowed'
         )}
       >
         <div className="flex flex-col items-center gap-2">
-          <span 
-            className="text-3xl sm:text-4xl" 
-            role="img" 
+          <span
+            className="text-3xl sm:text-4xl"
+            role="img"
             aria-label={sound.name}
           >
             {sound.category === 'animals' && '🐕'}
@@ -94,11 +98,11 @@ export function SoundButton({ sound, size = 'large', className }: SoundButtonPro
             {sound.id === 'success' && '🎉'}
             {sound.id === 'encourage' && '💪'}
           </span>
-          
+
           <span className="text-child-small font-bold text-center leading-tight">
             {sound.name}
           </span>
-          
+
           <span className="text-child-xs text-gray-600 text-center leading-tight">
             {sound.description}
           </span>

--- a/components/features/sound-play/SoundCategory.tsx
+++ b/components/features/sound-play/SoundCategory.tsx
@@ -2,7 +2,7 @@
 
 import { CircleButton } from '@/components/ui/CircleButton';
 import { type SoundCategory as SoundCategoryType } from '@/lib/constants/sounds';
-import { cn } from '@/utils/cn';
+import { cn } from '@/lib/utils/cn';
 
 interface CategoryInfo {
   id: SoundCategoryType;
@@ -19,30 +19,35 @@ interface SoundCategoryProps {
   className?: string;
 }
 
-const COLOR_MAP: Record<SoundCategoryType, 'pink' | 'yellow' | 'mint' | 'blue' | 'orange' | 'purple' | 'brown'> = {
+const COLOR_MAP: Record<
+  SoundCategoryType,
+  'pink' | 'yellow' | 'mint' | 'blue' | 'orange' | 'purple' | 'brown'
+> = {
   animals: 'pink',
-  instruments: 'mint', 
+  instruments: 'mint',
   effects: 'yellow',
-  background: 'blue'
+  background: 'blue',
 };
 
-export function SoundCategory({ 
-  categories, 
-  activeCategory, 
+export function SoundCategory({
+  categories,
+  activeCategory,
   onCategoryChange,
-  className 
+  className,
 }: SoundCategoryProps) {
   return (
-    <div className={cn(
-      "flex justify-center gap-4 p-4",
-      "bg-white/50 backdrop-blur-sm rounded-kotochan",
-      "border border-white/20 shadow-sm",
-      className
-    )}>
+    <div
+      className={cn(
+        'flex justify-center gap-4 p-4',
+        'bg-white/50 backdrop-blur-sm rounded-kotochan',
+        'border border-white/20 shadow-sm',
+        className
+      )}
+    >
       {categories.map((category) => {
         const isActive = category.id === activeCategory;
         const buttonColor = COLOR_MAP[category.id] || 'pink';
-        
+
         return (
           <CircleButton
             key={category.id}
@@ -50,17 +55,13 @@ export function SoundCategory({
             color={buttonColor}
             size="medium"
             className={cn(
-              "transition-all duration-200",
-              isActive && "scale-110 shadow-lg ring-2 ring-white/50",
-              !isActive && "opacity-70 hover:opacity-100"
+              'transition-all duration-200',
+              isActive && 'scale-110 shadow-lg ring-2 ring-white/50',
+              !isActive && 'opacity-70 hover:opacity-100'
             )}
           >
             <div className="flex flex-col items-center gap-1">
-              <span 
-                className="text-2xl" 
-                role="img" 
-                aria-label={category.name}
-              >
+              <span className="text-2xl" role="img" aria-label={category.name}>
                 {category.icon}
               </span>
               <span className="text-child-xs font-bold text-center leading-tight">


### PR DESCRIPTION
## Summary
- サウンドプレイ関連コンポーネントのユーティリティ参照パスを修正しビルドエラーを防止
- おえかきキャンバスのリサイズ時に履歴を復元し、白紙状態も履歴へ登録して取り消しや保存が安定するように改善
- 履歴が空のときのキャンバス初期化を追加して「きれいに」実行時も確実に白紙へ戻るように変更

## Testing
- pnpm lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e23fe284083338c69293892b5f5ea)